### PR TITLE
Fix compatibility with RequireJS in GLSL syntax highlighting brush

### DIFF
--- a/core/dependencies/syntaxhighlighter_3.0.83/shBrushGLSL.js
+++ b/core/dependencies/syntaxhighlighter_3.0.83/shBrushGLSL.js
@@ -17,7 +17,9 @@
 ;(function()
 {
 	// CommonJS
-	typeof(require) != 'undefined' ? SyntaxHighlighter = require('shCore').SyntaxHighlighter : null;
+	if (typeof(SyntaxHighlighter) == 'undefined' && typeof(require) != 'undefined') {
+		SyntaxHighlighter = require('shCore').SyntaxHighlighter;
+	}
 
 	function Brush()
 	{


### PR DESCRIPTION
WebGL Inspector fails on sites that use RequireJS. The GLSL syntax highlighting brush assumes that the presence of the `require` global means that the script is running as a CommonJS module. However, RequireJS too defines a global with the same name. The attached commit changes the brush to also check that the `SyntaxHighlighter` global is not already present, restoring compatibility with RequireJS.
