### PR TITLE
Fix requestAnimationFrame interception

### DIFF
--- a/core/host/CaptureContext.js
+++ b/core/host/CaptureContext.js
@@ -388,15 +388,18 @@
             (function(name) {
                 var originalFn = window[name];
                 var lastFrameTime = (new Date());
-                window[name] = function(code, element) {
+                window[name] = function(callback, element) {
                     var time = (new Date());
                     var delta = (time - lastFrameTime);
-                    var wrappedCode = wrapCode(code);
                     if (delta > timerHijacking.value) {
                         lastFrameTime = time;
-                        return originalFn.call(window, wrappedCode, element);
+                        var wrappedCallback = function() {
+                          callback();
+                          host.frameTerminator.fire();
+                        };
+                        return originalFn.call(window, wrappedCallback, element);
                     } else {
-                        window.setTimeout(code, delta);
+                        window.setTimeout(callback, delta);
                     }
                 };
             })(name);


### PR DESCRIPTION
requestAnimationFrame interception is currently broken and throws an exception (splice called with undefined). It's using wrapCode which is expecting setTimeout style params which is not what requestAnimationFrame uses.
