### PR TITLE
Fix for TRIANGLES, TRIANGLE_STRIP, and TRIANGLE_FAN being in the wrong order.

### DIFF
--- a/core/shared/Info.js
+++ b/core/shared/Info.js
@@ -199,12 +199,12 @@
                 new FunctionParam(gl, "index", new UIInfo(UIType.LONG))
             ]),
             new FunctionInfo(gl, "drawArrays", null, [
-                new FunctionParam(gl, "mode", new UIInfo(UIType.ENUM, ["POINTS", "LINE_STRIP", "LINE_LOOP", "LINES", "TRIANGLE_STRIP", "TRIANGLE_FAN", "TRIANGLES"])),
+                new FunctionParam(gl, "mode", new UIInfo(UIType.ENUM, ["POINTS", "LINE_STRIP", "LINE_LOOP", "LINES", "TRIANGLES", "TRIANGLE_STRIP", "TRIANGLE_FAN"])),
                 new FunctionParam(gl, "first", new UIInfo(UIType.LONG)),
                 new FunctionParam(gl, "count", new UIInfo(UIType.LONG))
             ], FunctionType.DRAW),
             new FunctionInfo(gl, "drawElements", null, [
-                new FunctionParam(gl, "mode", new UIInfo(UIType.ENUM, ["POINTS", "LINE_STRIP", "LINE_LOOP", "LINES", "TRIANGLE_STRIP", "TRIANGLE_FAN", "TRIANGLES"])),
+                new FunctionParam(gl, "mode", new UIInfo(UIType.ENUM, ["POINTS", "LINE_STRIP", "LINE_LOOP", "LINES", "TRIANGLES", "TRIANGLE_STRIP", "TRIANGLE_FAN"])),
                 new FunctionParam(gl, "count", new UIInfo(UIType.LONG)),
                 new FunctionParam(gl, "type", new UIInfo(UIType.ENUM, ["UNSIGNED_BYTE", "UNSIGNED_SHORT"])),
                 new FunctionParam(gl, "offset", new UIInfo(UIType.LONG))

--- a/core/ui/tabs/buffers/BufferView.js
+++ b/core/ui/tabs/buffers/BufferView.js
@@ -327,7 +327,7 @@
             {
                 var col1 = document.createElement("td");
                 var modeSelect = document.createElement("select");
-                var modeEnums = ["POINTS", "LINE_STRIP", "LINE_LOOP", "LINES", "TRIANGLE_STRIP", "TRIANGLE_FAN", "TRIANGLES"];
+                var modeEnums = ["POINTS", "LINE_STRIP", "LINE_LOOP", "LINES", "TRIANGLES", "TRIANGLE_STRIP", "TRIANGLE_FAN"];
                 for (var n = 0; n < modeEnums.length; n++) {
                     var option = document.createElement("option");
                     option.innerHTML = modeEnums[n];


### PR DESCRIPTION
Fix for TRIANGLES, TRIANGLE_STRIP, and TRIANGLE_FAN being in the wrong order.  Now they are in the order the enum is in the WebGL spec.
