### PR TITLE
As script tags may also appear in the body, do not just search head

### DIFF
--- a/core/embed.js
+++ b/core/embed.js
@@ -9,7 +9,7 @@
     var useDebug = window["gliEmbedDebug"];
 
     // Find self in the <script> tags
-    var scripts = document.head.getElementsByTagName("script");
+    var scripts = document.getElementsByTagName("script");
     for (var n = 0; n < scripts.length; n++) {
         var scriptTag = scripts[n];
         var src = scriptTag.src.toLowerCase();


### PR DESCRIPTION
I had some trouble getting WebGL-Inspector to work because I placed my script tags in the body (which is valid: http://www.w3.org/TR/html4/struct/global.html#h-7.5.1). This change will find all script tags in the document.
