### PR TITLE
Fix WebGL inspector interfering with the WEBGL_depth_texture extension.

### DIFF
--- a/core/host/CaptureContext.js
+++ b/core/host/CaptureContext.js
@@ -240,7 +240,7 @@
             'OES_standard_derivatives',
             'OES_element_index_uint',
             'EXT_texture_filter_anisotropic',
-            'OES_depth_texture',
+            'WEBGL_depth_texture',
             'WEBGL_compressed_texture_s3tc',
             'MOZ_WEBGL_compressed_texture_s3tc',
             'WEBKIT_WEBGL_compressed_texture_s3tc'


### PR DESCRIPTION
Currently, WebGL causes the WEBGL_depth_texture extension to fail to load. This CL fixes that bug.
