### PR TITLE
fix most strict mode warnings Fixes #109

### DIFF
--- a/core/host/CaptureContext.js
+++ b/core/host/CaptureContext.js
@@ -251,11 +251,10 @@
         }
         function containsInsensitive(list, name) {
             name = name.toLowerCase();
-            for (var n = 0; n < list.length; n++) {
-                if (list[n].toLowerCase() == name) {
-                    return true;
-                }
+            for (var n = 0, len = list.length; n < len; ++n) {
+                if (list[n].toLowerCase() === name) return true;
             }
+            return false;
         };
         var original_getSupportedExtensions = this.getSupportedExtensions;
         this.getSupportedExtensions = function() {
@@ -475,7 +474,7 @@
         "operaRequestAnimationFrame",
         "msAnimationFrame"
     ];
-    for (var n = 0; n < requestAnimationFrameNames.length; n++) {
+    for (var n = 0, len = requestAnimationFrameNames.length; n < len; ++n) {
         var name = requestAnimationFrameNames[n];
         if (window[name]) {
             (function(name) {
@@ -498,6 +497,7 @@
                         window.setTimeout(function() {
                             callback(Date.now());
                         }, delta);
+                        return null;
                     }
                 };
             })(name);

--- a/core/host/Resource.js
+++ b/core/host/Resource.js
@@ -99,12 +99,7 @@
     };
 
     Resource.prototype.setName = function (name, ifNeeded) {
-        if (ifNeeded) {
-            if (this.target.displayName) {
-                return;
-            }
-        }
-        if (this.target.displayName != name) {
+        if (!ifNeeded && this.target.displayName && this.target.displayName !== name) {
             this.target.displayName = name;
             this.modified.fireDeferred(this);
         }

--- a/core/host/resources/Buffer.js
+++ b/core/host/resources/Buffer.js
@@ -100,7 +100,7 @@
         // This is constant, so fetch once
         var maxVertexAttribs = gl.rawgl.getParameter(gl.MAX_VERTEX_ATTRIBS);
 
-        function assignDrawStructure(arguments) {
+        function assignDrawStructure () {
             var rawgl = gl.rawgl;
             var mode = arguments[0];
 
@@ -193,7 +193,7 @@
         gl.drawArrays = function () {
             //void drawArrays(GLenum mode, GLint first, GLsizei count);
             if (gl.captureFrame) {
-                assignDrawStructure(arguments);
+                assignDrawStructure.apply(null, arguments);
             }
 
             // Track draw stats
@@ -208,7 +208,7 @@
         gl.drawElements = function () {
             //void drawElements(GLenum mode, GLsizei count, GLenum type, GLsizeiptr offset);
             if (gl.captureFrame) {
-                assignDrawStructure(arguments);
+                assignDrawStructure.apply(null, arguments);
             }
 
             // Track draw stats

--- a/core/host/resources/Program.js
+++ b/core/host/resources/Program.js
@@ -65,7 +65,7 @@
 
                 var isSampler = false;
                 var textureType;
-                var bindingEnum;
+                var bindingType;
                 var textureValue = null;
                 switch (activeInfo.type) {
                     case gl.SAMPLER_2D:

--- a/core/replay/RedundancyChecker.js
+++ b/core/replay/RedundancyChecker.js
@@ -404,6 +404,8 @@
                     return this.stateCache["ARRAY_BUFFER_BINDING"] == buffer;
                 case this.ELEMENT_ARRAY_BUFFER:
                     return this.stateCache["ELEMENT_ARRAY_BUFFER_BINDING"] == buffer;
+                default:
+                    return false;
             }
         },
         bindFramebuffer: function (target, framebuffer) {
@@ -420,6 +422,7 @@
                 case this.TEXTURE_CUBE_MAP:
                     return this.stateCache["TEXTURE_BINDING_CUBE_MAP_" + activeTexture] == texture;
             }
+            return false;
         },
         blendEquation: function (mode) {
             return (this.stateCache["BLEND_EQUATION_RGB"] == mode) && (this.stateCache["BLEND_EQUATION_ALPHA"] == mode);
@@ -477,6 +480,8 @@
                     return this.stateCache["SCISSOR_TEST"] == false;
                 case this.STENCIL_TEST:
                     return this.stateCache["STENCIL_TEST"] == false;
+                default:
+                    return false;
             }
         },
         disableVertexAttribArray: function (index) {
@@ -500,6 +505,8 @@
                     return this.stateCache["SCISSOR_TEST"] == true;
                 case this.STENCIL_TEST:
                     return this.stateCache["STENCIL_TEST"] == true;
+                default:
+                    return false;
             }
         },
         enableVertexAttribArray: function (index) {
@@ -512,6 +519,8 @@
             switch (target) {
                 case this.GENERATE_MIPMAP_HINT:
                     return this.stateCache["GENERATE_MIPMAP_HINT"] == mode;
+                default:
+                    return false;
             }
         },
         lineWidth: function (width) {
@@ -529,6 +538,8 @@
                     return this.stateCache["UNPACK_FLIP_Y_WEBGL"] == param;
                 case this.UNPACK_PREMULTIPLY_ALPHA_WEBGL:
                     return this.stateCache["UNPACK_PREMULTIPLY_ALPHA_WEBGL"] == param;
+                default:
+                    return false;
             }
         },
         polygonOffset: function (factor, units) {
@@ -554,6 +565,8 @@
                 case this.FRONT_AND_BACK:
                     return (this.stateCache["STENCIL_FUNC"] == func) && (this.stateCache["STENCIL_REF"] == ref) && (this.stateCache["STENCIL_VALUE_MASK"] == mask) &&
                            (this.stateCache["STENCIL_BACK_FUNC"] == func) && (this.stateCache["STENCIL_BACK_REF"] == ref) && (this.stateCache["STENCIL_BACK_VALUE_MASK"] == mask);
+                default:
+                    return false;
             }
         },
         stencilMask: function (mask) {
@@ -567,6 +580,8 @@
                     return this.stateCache["STENCIL_BACK_WRITEMASK"] == mask;
                 case this.FRONT_AND_BACK:
                     return (this.stateCache["STENCIL_WRITEMASK"] == mask) && (this.stateCache["STENCIL_BACK_WRITEMASK"] == mask);
+                default:
+                    return false;
             }
         },
         stencilOp: function (fail, zfail, zpass) {
@@ -582,6 +597,8 @@
                 case this.FRONT_AND_BACK:
                     return (this.stateCache["STENCIL_FAIL"] == fail) && (this.stateCache["STENCIL_PASS_DEPTH_FAIL"] == zfail) && (this.stateCache["STENCIL_PASS_DEPTH_PASS"] == zpass) &&
                            (this.stateCache["STENCIL_BACK_FAIL"] == fail) && (this.stateCache["STENCIL_BACK_PASS_DEPTH_FAIL"] == zfail) && (this.stateCache["STENCIL_BACK_PASS_DEPTH_PASS"] == zpass);
+                default:
+                    return false;
             }
         },
         uniformN: function (location, v) {

--- a/core/shared/Extensions.js
+++ b/core/shared/Extensions.js
@@ -50,12 +50,9 @@
             return;
         }
 
-        var extensionNames = gl.getSupportedExtensions();
-        for (var n = 0; n < extensionNames.length; n++) {
-            var extensionName = extensionNames[n];
-            var extension = gl.getExtension(extensionName);
-            // Ignore result
-        }
+        gl.getSupportedExtensions().forEach(function (ext) {
+          if (ext.substr(0, 3) !== "MOZ") gl.getExtension(ext);
+        });
     };
 
 })();

--- a/core/ui/tabs/buffers/BufferView.js
+++ b/core/ui/tabs/buffers/BufferView.js
@@ -257,6 +257,49 @@
         gli.ui.appendParameters(gl, el, buffer, ["BUFFER_SIZE", "BUFFER_USAGE"], [null, ["STREAM_DRAW", "STATIC_DRAW", "DYNAMIC_DRAW"]]);
         gli.ui.appendbr(el);
 
+        function updatePreviewSettings () {
+            var options = buffer.previewOptions;
+
+            // Draw options
+            options.mode = gl.POINTS + modeSelect.selectedIndex;
+            options.positionIndex = attributeSelect.selectedIndex;
+            options.position = version.structure[options.positionIndex];
+
+            // Element array buffer options
+            if (elementArraySelect.selectedIndex === 0) {
+                // Unindexed
+                options.elementArrayBuffer = null;
+            } else {
+                var option = elementArraySelect.options[elementArraySelect.selectedIndex];
+                var elid = parseInt(option.value, 10);
+                var elbuffer = gl.resources.getResourceById(elid);
+                options.elementArrayBuffer = [elbuffer, elbuffer.currentVersion];
+            }
+            switch (sizeSelect.selectedIndex) {
+                case 0:
+                    options.elementArrayType = gl.UNSIGNED_BYTE;
+                    break;
+                case 1:
+                    options.elementArrayType = gl.UNSIGNED_SHORT;
+                    break;
+            }
+
+            // Range options
+            if (options.elementArrayBuffer) {
+                options.offset = parseInt(startInput.value, 10);
+            } else {
+                options.first = parseInt(startInput.value, 10);
+            }
+            options.count = parseInt(countInput.value, 10);
+
+            try {
+                view.inspector.setBuffer(buffer, version);
+            } catch (e) {
+                view.inspector.setBuffer(null, null);
+                console.log("exception while setting buffer preview: " + e);
+            }
+        };
+
         var showPreview = shouldShowPreview(gl, buffer, version);
         if (showPreview) {
             gli.ui.appendSeparator(el);
@@ -271,49 +314,6 @@
             // Tools for choosing preview options
             var previewOptions = document.createElement("table");
             previewOptions.className = "buffer-preview";
-
-            function updatePreviewSettings() {
-                var options = buffer.previewOptions;
-
-                // Draw options
-                options.mode = gl.POINTS + modeSelect.selectedIndex;
-                options.positionIndex = attributeSelect.selectedIndex;
-                options.position = version.structure[options.positionIndex];
-
-                // Element array buffer options
-                if (elementArraySelect.selectedIndex == 0) {
-                    // Unindexed
-                    options.elementArrayBuffer = null;
-                } else {
-                    var option = elementArraySelect.options[elementArraySelect.selectedIndex];
-                    var elid = parseInt(option.value);
-                    var elbuffer = gl.resources.getResourceById(elid);
-                    options.elementArrayBuffer = [elbuffer, elbuffer.currentVersion];
-                }
-                switch (sizeSelect.selectedIndex) {
-                    case 0:
-                        options.elementArrayType = gl.UNSIGNED_BYTE;
-                        break;
-                    case 1:
-                        options.elementArrayType = gl.UNSIGNED_SHORT;
-                        break;
-                }
-
-                // Range options
-                if (options.elementArrayBuffer) {
-                    options.offset = parseInt(startInput.value);
-                } else {
-                    options.first = parseInt(startInput.value);
-                }
-                options.count = parseInt(countInput.value);
-
-                try {
-                    view.inspector.setBuffer(buffer, version);
-                } catch (e) {
-                    view.inspector.setBuffer(null, null);
-                    console.log("exception while setting buffer preview: " + e);
-                }
-            };
 
             // Draw settings
             var drawRow = document.createElement("tr");

--- a/core/ui/tabs/timeline/TimelineView.js
+++ b/core/ui/tabs/timeline/TimelineView.js
@@ -14,6 +14,38 @@
 
         this.displayCanvas = elementRoot.getElementsByClassName("timeline-canvas")[0];
 
+        function appendKeyRow(keyRoot, counter) {
+            var row = document.createElement("div");
+            row.className = "timeline-key-row";
+            if (counter.enabled) {
+                row.className += " timeline-key-row-enabled";
+            }
+
+            var colorEl = document.createElement("div");
+            colorEl.className = "timeline-key-color";
+            colorEl.style.backgroundColor = counter.color;
+            row.appendChild(colorEl);
+
+            var nameEl = document.createElement("div");
+            nameEl.className = "timeline-key-name";
+            nameEl.textContent = counter.description;
+            row.appendChild(nameEl);
+
+            keyRoot.appendChild(row);
+
+            row.onclick = function () {
+                counter.enabled = !counter.enabled;
+                if (!counter.enabled) {
+                    row.className = row.className.replace(" timeline-key-row-enabled", "");
+                } else {
+                    row.className += " timeline-key-row-enabled";
+                }
+
+                gli.settings.session.counterToggles[counter.name] = counter.enabled;
+                gli.settings.save();
+            };
+        };
+
         if (gli.settings.session.enableTimeline) {
             this.displayCanvas.width = 800;
             this.displayCanvas.height = 200;
@@ -45,38 +77,6 @@
                     }
                 }
             }
-
-            function appendKeyRow(keyRoot, counter) {
-                var row = document.createElement("div");
-                row.className = "timeline-key-row";
-                if (counter.enabled) {
-                    row.className += " timeline-key-row-enabled";
-                }
-
-                var colorEl = document.createElement("div");
-                colorEl.className = "timeline-key-color";
-                colorEl.style.backgroundColor = counter.color;
-                row.appendChild(colorEl);
-
-                var nameEl = document.createElement("div");
-                nameEl.className = "timeline-key-name";
-                nameEl.textContent = counter.description;
-                row.appendChild(nameEl);
-
-                keyRoot.appendChild(row);
-
-                row.onclick = function () {
-                    counter.enabled = !counter.enabled;
-                    if (!counter.enabled) {
-                        row.className = row.className.replace(" timeline-key-row-enabled", "");
-                    } else {
-                        row.className += " timeline-key-row-enabled";
-                    }
-
-                    gli.settings.session.counterToggles[counter.name] = counter.enabled;
-                    gli.settings.save();
-                };
-            };
 
             var keyRoot = document.createElement("div");
             keyRoot.className = "timeline-key";

--- a/core/ui/tabs/trace/TraceListing.js
+++ b/core/ui/tabs/trace/TraceListing.js
@@ -159,19 +159,11 @@
 
         this.activeCall = callIndex;
 
-        if (callIndex === null) {
-            if (!ignoreScroll) {
-                this.scrollToCall(0);
-            }
-        } else {
-            var el = this.calls[callIndex].element;
-            el.className += " trace-call-highlighted";
-            var icon = this.calls[callIndex].icon;
-            icon.className += " trace-call-icon-active";
+        this.calls[callIndex].element.classList.add("trace-call-highlighted");
+        this.calls[callIndex].icon.classList.add("trace-call-icon-active");
 
-            if (!ignoreScroll) {
-                this.scrollToCall(callIndex);
-            }
+        if (!ignoreScroll) {
+            this.scrollToCall(callIndex);
         }
     };
 

--- a/core/ui/tabs/trace/TraceTab.js
+++ b/core/ui/tabs/trace/TraceTab.js
@@ -45,7 +45,10 @@
             this.traceView.setFrame(frame);
         });
 
-        var scrollStates = {};
+        var scrollStates = {
+            listing: null,
+            traceView: null,
+        };
         this.lostFocus.addListener(this, function () {
             scrollStates.listing = this.listing.getScrollState();
             scrollStates.traceView = this.traceView.getScrollState();

--- a/core/ui/tabs/trace/TraceView.js
+++ b/core/ui/tabs/trace/TraceView.js
@@ -184,7 +184,9 @@
     };
     TraceMinibar.prototype.refreshState = function (ignoreScroll) {
         //var newState = new gli.StateCapture(this.replaygl);
-        this.view.traceListing.setActiveCall(this.lastCallIndex, ignoreScroll);
+        if (this.lastCallIndex) {
+            this.view.traceListing.setActiveCall(this.lastCallIndex, ignoreScroll);
+        }
         //this.window.stateHUD.showState(newState);
         //this.window.outputHUD.refresh();
 


### PR DESCRIPTION
This takes care of most of the strict mode warnings and really cleans up the console, allowing you to more easily differentiate between your bugs vs bugs in the inspector.  There's a ton in the syntax highlighter, which I should just fix upstream, so they're not in this patch.  There's also one [colossus mega function](https://github.com/benvanik/WebGL-Inspector/blob/7185ad7db30f1c9318fe9268ef88120fb9ce8754/core/ui/pixelhistory/PixelHistory.js#L160-L272) that I punted on because it closes over so many variables.  I'll open a new bug for that.
