### PR TITLE
Add context attributes to state tab

### DIFF
--- a/core/ui/Window.js
+++ b/core/ui/Window.js
@@ -438,6 +438,9 @@
 
         table.appendChild(tr);
     };
+    function appendContextAttributeRow(w, gl, table, state, param) {
+        gli.ui.appendStateParameterRow(w, gl, table, state, {name: param, ui: { type: gli.UIType.BOOL }});
+    }
     function appendMatrices(gl, el, type, size, value) {
         switch (type) {
             case gl.FLOAT_MAT2:
@@ -554,6 +557,7 @@
     ui.appendSeparator = appendSeparator;
     ui.appendParameters = appendParameters;
     ui.appendStateParameterRow = appendStateParameterRow;
+    ui.appendContextAttributeRow = appendContextAttributeRow;
     ui.appendMatrices = appendMatrices;
     ui.appendMatrix = appendMatrix;
     ui.appendArray = appendArray;

--- a/core/ui/tabs/state/StateView.js
+++ b/core/ui/tabs/state/StateView.js
@@ -27,6 +27,20 @@
         }
 
         el.appendChild(table);
+
+        titleDiv = document.createElement("div");
+        titleDiv.className = "info-title-master";
+        titleDiv.textContent = "Canvas Attributes";
+        el.appendChild(titleDiv);
+
+        table = document.createElement("table");
+        table.className = "info-parameters";
+        var attribs = gl.getContextAttributes();
+        Object.keys(attribs).forEach(function(key) {
+            gli.ui.appendContextAttributeRow(w, gl, table, attribs, key);
+        });
+
+        el.appendChild(table);
     };
 
     StateView.prototype.setState = function () {


### PR DESCRIPTION
Hey Ben, I don't know if you're maintaining this at all anymore or what. I think someone mentioned WTF but that doesn't seem to have all the same functionality.

Anyway, often need to know the context attributes so I hacked them into the state tab. If this sucks and there's some other way you'd accept a pull request I'd be happy to change it.
