### PR TITLE
Fix boundary bug while stepping calls

### DIFF
--- a/core/replay/Controller.js
+++ b/core/replay/Controller.js
@@ -149,7 +149,7 @@
     };
 
     Controller.prototype.stepBackward = function () {
-        if (this.callIndex == 0) {
+        if (this.callIndex <= 1) {
             return false;
         }
         return this.stepUntil(this.callIndex - 2);

--- a/core/ui/tabs/trace/TraceView.js
+++ b/core/ui/tabs/trace/TraceView.js
@@ -51,6 +51,7 @@
             if (this.controller.stepForward() == false) {
                 this.controller.reset();
                 this.controller.openFrame(this.view.frame);
+                this.controller.stepForward();
             }
             this.refreshState();
         });
@@ -71,6 +72,7 @@
         */
         addButton(this.elements.bar, "restart", "Restart from the beginning of the frame (F10)", function () {
             this.controller.openFrame(this.view.frame);
+            this.controller.stepForward();
             this.refreshState();
         });
 
@@ -184,7 +186,7 @@
     };
     TraceMinibar.prototype.refreshState = function (ignoreScroll) {
         //var newState = new gli.StateCapture(this.replaygl);
-        if (this.lastCallIndex) {
+        if (this.lastCallIndex != null) {
             this.view.traceListing.setActiveCall(this.lastCallIndex, ignoreScroll);
         }
         //this.window.stateHUD.showState(newState);


### PR DESCRIPTION
On my Firefox 39, there exists bugs like that I can't step to call 0 (neither click it directly or press step backward button) and some unexpected behaviours. This commit fix those problems, at least it work fine on my browser.

And, one thing I'm not very sure about is the behaviour when I click at the last call then press step forward button, should it loop to the first call (index 0)? Since it performs looping when I installed it, I make it loops for now.