### PR TITLE
Fix incorrect shebang in buildextensions

### DIFF
--- a/core/buildextensions.sh
+++ b/core/buildextensions.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -e # halt on failure
 # Get the scripts absolute path
 pushd `dirname $0` > /dev/null
 SCRIPTPATH=`pwd`


### PR DESCRIPTION
`buildextensions.sh` makes use of pushd and popd - these are bash features not present in /bin/sh, resulting in command not found errors.

Additionally, adding set -e, so that script aborts on failure, for example NPM not being installed.